### PR TITLE
Implement Promise.all

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This Promise implementation attempts to satisfy those traits.
 	* Creates an immediately rejected Promise with the given value.
 * `Promise.is(object) -> bool`
 	* Returns whether the given object is a Promise.
+* `Promise.all(array) -> array`
+	* Accepts an array of promises and returns a new promise that:
+		* is resolved after all input promises resolve.
+		* is rejected if ANY input promises reject.
+	* Note: Only the first return value from each promise will be present in the resulting array.
 
 ### Instance Methods
 * `Promise:andThen(successHandler, [failureHandler]) -> Promise`
@@ -69,8 +74,6 @@ httpGet("https://google.com")
 ```
 
 ## Future Additions
-* `Promise.all`
-	* Currently stubbed out, throws an error.
 * `Promise.wrapAsync`
 	* Intended to wrap an existing Roblox API that yields, exposing a new one that returns a Promise.
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -179,7 +179,9 @@ function Promise.all(promises)
 			end
 		end
 
-		for i, value in ipairs(promises) do
+		-- Loop over numerically so as to allow holey arrays.
+		for i = 1, #promises do
+			local value = promises[i]
 			-- Pass value through if it's not actually a promise.
 			if Promise.is(value) then
 				value:andThen(function(...)

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -166,7 +166,7 @@ function Promise.all(promises)
 
 		-- Called when a single value is resolved and resolves if all are done.
 		local function resolveOne(i, ...)
-			if rejected == true then
+			if rejected then
 				-- Bail out if this promise has already been rejected.
 				return
 			end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -151,9 +151,6 @@ function Promise.all(promises)
 		error("Please pass an array of promises or values to Promise.all", 2)
 	end
 
-	-- A traceback for extra arguments warning
-	local source = debug.traceback()
-
 	-- If there are no values then return an already resolved promise.
 	if #promises == 0 then
 		return Promise.resolve({})
@@ -172,16 +169,6 @@ function Promise.all(promises)
 			if rejected == true then
 				-- Bail out if this promise has already been rejected.
 				return
-			end
-
-			if select("#", ...) > 1 then
-				local message = (
-					"When using Promise.all, extra return values are " ..
-					"discarded! See:\n\n%s"
-				):format(
-					source
-				)
-				warn(message)
 			end
 
 			resolvedValues[i] = ...

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -264,4 +264,62 @@ return function()
 			expect(#chained._values).to.equal(0)
 		end)
 	end)
+
+	describe("Promise.all", function()
+		FOCUS()
+		it("should error if given something other than a table", function()
+			expect(function()
+				Promise.all(1)
+			end).to.throw()
+		end)
+
+		it("should resolve instantly with an empty table if given no values", function()
+			local promise = Promise.all({})
+			local success, value = promise:await()
+
+			expect(success).to.equal(true)
+			expect(promise:getStatus()).to.equal(Promise.Status.Resolved)
+			expect(value).to.be.a("table")
+			expect(#value).to.equal(0)
+		end)
+
+		it("should let non-promise values pass through unchanged", function()
+			local values = {{}, {}, {}}
+			local promise = Promise.all(values)
+			local success, resolved = promise:await()
+
+			expect(success).to.equal(true)
+			expect(resolved[1]).to.equal(values[1])
+			expect(resolved[2]).to.equal(values[2])
+			expect(resolved[3]).to.equal(values[3])
+		end)
+
+		it("should wait for all promises to be resolved and return their values", function()
+			local promises = {
+				Promise.new(function(resolve)
+					resolve(1)
+				end),
+				Promise.new(function(resolve)
+					resolve("A string")
+				end),
+				Promise.new(function(resolve)
+					resolve(false)
+				end),
+				Promise.new(function(resolve)
+					resolve(nil)
+				end),
+			}
+
+			local promise = Promise.all(promises)
+			local success, resolved = promise:await()
+
+			expect(success).to.equal(true)
+			expect(resolved).to.be.a("table")
+			expect(#resolved).to.equal(3)
+			expect(resolved[1]).to.equal(1)
+			expect(resolved[2]).to.equal("A string")
+			expect(resolved[3]).to.equal(false)
+			expect(resolved[4]).to.equal(nil)
+		end)
+	end)
 end

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -302,11 +302,11 @@ return function()
 					resolve("A string")
 				end),
 				Promise.new(function(resolve)
-					resolve(false)
-				end),
-				Promise.new(function(resolve)
 					resolve(nil)
 				end),
+				Promise.new(function(resolve)
+					resolve(false)
+				end)
 			}
 
 			local promise = Promise.all(promises)
@@ -314,11 +314,11 @@ return function()
 
 			expect(success).to.equal(true)
 			expect(resolved).to.be.a("table")
-			expect(#resolved).to.equal(3)
+			expect(#resolved).to.equal(4)
 			expect(resolved[1]).to.equal(1)
 			expect(resolved[2]).to.equal("A string")
-			expect(resolved[3]).to.equal(false)
-			expect(resolved[4]).to.equal(nil)
+			expect(resolved[3]).to.equal(nil)
+			expect(resolved[4]).to.equal(false)
 		end)
 	end)
 end

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -266,7 +266,6 @@ return function()
 	end)
 
 	describe("Promise.all", function()
-		FOCUS()
 		it("should error if given something other than a table", function()
 			expect(function()
 				Promise.all(1)

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -282,15 +282,10 @@ return function()
 			expect(#value).to.equal(0)
 		end)
 
-		it("should let non-promise values pass through unchanged", function()
-			local values = {{}, {}, {}}
-			local promise = Promise.all(values)
-			local success, resolved = promise:await()
-
-			expect(success).to.equal(true)
-			expect(resolved[1]).to.equal(values[1])
-			expect(resolved[2]).to.equal(values[2])
-			expect(resolved[3]).to.equal(values[3])
+		it("should error if given non-promise values", function()
+			expect(function()
+				Promise.all({{}, {}, {}})
+			end).to.throw()
 		end)
 
 		it("should wait for all promises to be resolved and return their values", function()


### PR DESCRIPTION
This implements `Promise.all` along with tests and updated README docs. `Promise.all` accepts an array of promises and then returns a promise that resolves to an array of the resolved values from each promise. Accepting an returning an array makes for less chore work with unpacking and packing into a table and also parallels JavaScript's `Promise.all`. 

Demo use case:
```lua
local Promise = require(script.Parent.Promise)

local promises = {}

for i = 1, 10 do
	promises[i] = Promise.new(function(resolve, reject)
		spawn(function()
			wait(i)
			if i == 5 then
				-- reject("I hate the number 5")
			end
			resolve(i * 2, true)
		end)
	end)
end

Promise.all(promises)
	:andThen(function(values)
		for _, v in ipairs(values) do
			print(v)
		end
	end)
	:catch(function(err)
		print(err)
	end)
```