### PR TITLE
Implement finally and cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,12 @@ This Promise implementation attempts to satisfy those traits.
 ## API
 
 ### Static Functions
-* `Promise.new((resolve, reject) -> nil) -> Promise`
+* `Promise.new((resolve, reject, onCancel) -> nil) -> Promise`
 	* Construct a new Promise that will be resolved or rejected with the given callbacks.
+	* You may register an optional cancellation hook by using the `onCancel` argument.
+		* This should be used to abort any ongoing operations leading up to the promise being settled. 
+		* Call the `onCancel` function with a new function as its only argument to set a hook which will in turn be called when/if the promise is cancelled.
+		* When a promise is cancelled, calls to `resolve` or `reject` will be ignored, regardless of if you set a cancellation hook or not.
 * `Promise.resolve(value) -> Promise`
 	* Creates an immediately resolved Promise with the given value.
 * `Promise.reject(value) -> Promise`
@@ -37,6 +41,13 @@ This Promise implementation attempts to satisfy those traits.
 	* Equivalent to the Promise/A+ `then` method.
 * `Promise:catch(failureHandler) -> Promise`
 	* Shorthand for `Promise:andThen(nil, failureHandler)`.
+* `Promise:finally(finallyHandler) -> Promise`
+	* Set a handler that will be called regardless of the promise's fate. The handler is called when the promise is resolved, rejected, *or* cancelled.
+	* Returns a new promise chained from this promise.
+* `Promise:cancel() -> nil`
+	* Cancels this promise, preventing the promise from resolving or rejecting. Does not do anything if the promise is already settled.
+	* Cancellations will propagate upwards through chained promises.
+		* Promises will only be cancelled if all of their consumers are also cancelled. This is to say that if you call `andThen` twice on the same promise, and you cancel only one of the promises resulting from the `andThen` call, it will not cancel the parent promise until the other child promise is also cancelled.
 * `Promise:await() -> ok, value`
 	* Yields the current thread until the given Promise completes. Returns `ok` as a bool, followed by the value that the promise returned.
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This Promise implementation attempts to satisfy those traits.
 	* Construct a new Promise that will be resolved or rejected with the given callbacks.
 	* You may register an optional cancellation hook by using the `onCancel` argument.
 		* This should be used to abort any ongoing operations leading up to the promise being settled. 
-		* Call the `onCancel` function with a new function as its only argument to set a hook which will in turn be called when/if the promise is cancelled.
+		* Call the `onCancel` function with a function callback as its only argument to set a hook which will in turn be called when/if the promise is cancelled.
 		* When a promise is cancelled, calls to `resolve` or `reject` will be ignored, regardless of if you set a cancellation hook or not.
 * `Promise.resolve(value) -> Promise`
 	* Creates an immediately resolved Promise with the given value.

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -170,7 +170,11 @@ function Promise.new(callback, parent)
 	local function onCancel(cancellationHook)
 		assert(type(cancellationHook) == "function", "onCancel must be called with a function as its first argument.")
 
-		self._cancellationHook = cancellationHook
+		if self._status == Promise.Status.Cancelled then
+			cancellationHook()
+		else
+			self._cancellationHook = cancellationHook
+		end
 	end
 
 	local _, result = wpcallPacked(callback, resolve, reject, onCancel)

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -168,6 +168,8 @@ function Promise.new(callback, parent)
 	end
 
 	local function onCancel(cancellationHook)
+		assert(type(cancellationHook) == "function", "onCancel must be called with a function as its first argument.")
+
 		self._cancellationHook = cancellationHook
 	end
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -291,6 +291,13 @@ function Promise.prototype:catch(failureCallback)
 end
 
 --[[
+	Used to set a callback for when the promise resolves OR rejects.
+]]
+function Promise.prototype:finally(finallyCallback)
+	return self:andThen(finallyCallback, finallyCallback)
+end
+
+--[[
 	Yield until the promise is completed.
 
 	This matches the execution model of normal Roblox functions.

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -393,26 +393,26 @@ function Promise.prototype:await()
 	self._unhandledRejection = false
 
 	if self._status == Promise.Status.Started then
-		local ok, result, resultLength
+		local result
+		local resultLength
+		local bindable = Instance.new("BindableEvent")
 
-		local thread = coroutine.running()
-
-		spawn(function()
-			self:andThen(
-				function(...)
-					resultLength, result = pack(...)
-					ok = true
-				end,
-				function(...)
-					resultLength, result = pack(...)
-					ok = false
-				end
-			):finally(function()
-				coroutine.resume(thread)
-			end)
+		self:andThen(
+			function(...)
+				resultLength, result = pack(...)
+				bindable:Fire(true)
+			end,
+			function(...)
+				resultLength, result = pack(...)
+				bindable:Fire(false)
+			end
+		)
+		self:finally(function()
+			bindable:Fire(nil)
 		end)
 
-		coroutine.yield()
+		local ok = bindable.Event:Wait()
+		bindable:Destroy()
 
 		if ok == nil then
 			-- If cancelled, we return nil.


### PR DESCRIPTION
- Implement `promise:finally(handler) -> Promise`
- Adds cancellation

The two features are intertwined, so I've PR'd them together.

------------

"Finally" handlers are still called when a promise is cancelled, so it's not as easy as just doing `:andThen(handler, handler)`. I added a new queue for finally handlers, and a new method, `_finalize`, which calls all queued handlers. If you call `:finally` on an already-settled promise, the handler is immediately invoked instead of queued.

`:finally` follows a slimmed down version of the pattern seen in `andThen`, returning a chained promise resolved or rejected by an advancer with the given handler.

------------

The cancellation process is modeled after [bluebird's](http://bluebirdjs.com/docs/api/cancellation.html).

When a promise is cancelled, it has a status of "Cancelled".

Promise cancellation must propagate upwards through promise chains, so it was necessary to add a way to track when a promise is chained off of another promise. I added an internal property, `_parent`, which is set by passing the parent promise as an optional and undocumented second argument to the Promise.new constructor.

When a promise is chained via `andThen` or `finally`, the promise now keeps track of the number of consumers with a  `_numConsumers` property. When one of these consumers is cancelled, it calls a method on its parent promise which decreases the parent's `_numConsumers` by one. If the parent promise has no more consumers, it too is cancelled, and the process continues upwards until there are no more parents.

Promise callbacks are now sent a third function, `onCancel`, in addition to `resolve` and `reject`. When this new function is called with a callback as its argument, the callback is stored as the `_cancellationHook` property in the promise. When a promise is cancelled, its cancellation hook is called if it has been set. This allows the promise to abort any ongoing operations.

Promise cancellation does not propagate downstream. This means that if a promise is cancelled, and that promise had `andThen` called on it, the child promise will forever be in an unsettled state. This is also the case in Bluebird. However, this may be a footgun for developers so perhaps when a promise is cancelled it should also cancel any direct consumers as well.

------------

`promise:await` will return `nil` if the awaited Promise is cancelled. This should be an edge case (only possible if you have multiple consumers of a single promise, which is uncommon, but still possible). This felt like a better alternative than yielding forever.